### PR TITLE
pmd_wan to v1.2.0 and pyo3 to 0.13.2

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -91,8 +91,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64, path: mingw64, rust_target: x86_64-pc-windows-gnu, lib_dir: /mingw64/lib/ },
-          { msystem: MINGW32, arch: i686, path: mingw32, rust_target: i686-pc-windows-gnu, lib_dir: /mingw32/lib/ }
+          { msystem: MINGW64, arch: x86_64, path: mingw64, rust_target: x86_64-pc-windows-gnu, lib_dir: /mingw64/lib/, include_dir: /mingw64/include/python3.8/ },
+          { msystem: MINGW32, arch: i686, path: mingw32, rust_target: i686-pc-windows-gnu, lib_dir: /mingw32/lib/, include_dir: /mingw32/include/python3.8/ }
         ]
     steps:
       - name: Install MSys2 and dependencies
@@ -144,6 +144,7 @@ jobs:
         env:
           CARGO_BUILD_TARGET: ${{ matrix.rust_target }}
           PYO3_CROSS_LIB_DIR: ${{ matrix.lib_dir }}
+          PYO3_CROSS_INCLUDE_DIR: ${{ matrix.include_dir }}
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -91,8 +91,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { msystem: MINGW64, arch: x86_64, path: mingw64, rust_target: x86_64-pc-windows-gnu },
-          { msystem: MINGW32, arch: i686, path: mingw32, rust_target: i686-pc-windows-gnu }
+          { msystem: MINGW64, arch: x86_64, path: mingw64, rust_target: x86_64-pc-windows-gnu, lib_dir: /mingw64/lib/ },
+          { msystem: MINGW32, arch: i686, path: mingw32, rust_target: i686-pc-windows-gnu, lib_dir: /mingw32/lib/ }
         ]
     steps:
       - name: Install MSys2 and dependencies
@@ -143,6 +143,7 @@ jobs:
           PATH="$PATH:/c/Rust/.cargo/bin" python setup.py bdist_wheel
         env:
           CARGO_BUILD_TARGET: ${{ matrix.rust_target }}
+          PYO3_CROSS_LIB_DIR: ${{ matrix.lib_dir }}
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 name = "skytemple_rust"
 
 [dependencies]
-pyo3 = { version = "0.10.1", features = ["extension-module"] }
+pyo3 = { version = "0.13.2", features = ["extension-module"] }
 pmd_wan = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ name = "skytemple_rust"
 
 [dependencies]
 pyo3 = { version = "0.10.1", features = ["extension-module"] }
-pmd_wan = { git = "https://github.com/SkyTemple/pmd_wan", branch = "props-support" }
+pmd_wan = "1.2.0"

--- a/src/pmd_wan.rs
+++ b/src/pmd_wan.rs
@@ -316,11 +316,11 @@ impl WanImage {
 fn convert_error(err: lib::WanError) -> PyErr {
     match err {
         WanError::IOError(_) => 
-            exceptions::IOError::py_err(
+            exceptions::PyIOError::new_err(
                 "an io error happened"
             ),
         err =>
-            exceptions::ValueError::py_err(
+            exceptions::PyValueError::new_err(
                 format!("{}", err)
             ),
     }

--- a/src/pmd_wan.rs
+++ b/src/pmd_wan.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
-use pmd_wan::wan as lib;
+use pmd_wan as lib;
 use std::io::Cursor;
-use pmd_wan::wan::WanError;
+use pmd_wan::WanError;
 use pyo3::exceptions;
 
 /// A PMD2 WAN sprite.
@@ -319,69 +319,9 @@ fn convert_error(err: lib::WanError) -> PyErr {
             exceptions::IOError::py_err(
                 "an io error happened"
             ),
-        WanError::ImageIDPointBackButFirstImage => 
+        err =>
             exceptions::ValueError::py_err(
-                "an image id point to the same than the previous one, but it is the first image"
-            ),
-        WanError::MetaFrameLessThanLessOne(id) => 
-            exceptions::ValueError::py_err(
-                format!("a metaframe is inferior to -1, but that is not valid (it actually is {})", id)
-            ),
-        WanError::InvalidOffset => 
-            exceptions::ValueError::py_err(
-                "in the creation of a meta frame store: the check for the offset of the pointer of the animation group are not valid!"
-            ),
-        WanError::InvalidResolution => 
-            exceptions::ValueError::py_err(
-                "the resolution was not found!!!"
-            ),
-        WanError::IncoherentPointerToImagePart => 
-            exceptions::ValueError::py_err(
-                "pointer to image parts are not coherent."
-            ),
-        WanError::NoZIndex => 
-            exceptions::ValueError::py_err(
-                "impossible to find a definied z_index (the image is probably empty)!!! aborting"
-            ),
-        WanError::ImpossibleAlphaLevel => 
-            exceptions::ValueError::py_err(
-                "an impossible alpha level was found in the picture !"
-            ),
-        WanError::NullImagePointer => 
-            exceptions::ValueError::py_err(
-                "an image data pointer is null !!!"
-            ),
-        WanError::ImageWithoutResolution => 
-            exceptions::ValueError::py_err(
-                "the image does not have a resolution"
-            ),
-        WanError::PaletteDontEndWithZero => 
-            exceptions::ValueError::py_err(
-                "the palette data doesn't end with 0s !!!"
-            ),
-        WanError::PaletteOOB => 
-            exceptions::ValueError::py_err(
-                "impossible to get a color in the palette, as this will do an OOB."
-            ),
-        WanError::CantFindColorInPalette => 
-            exceptions::ValueError::py_err(
-                "impossible to find the specified color in the palette!"
-            ),
-        WanError::InvalidSir0(value) => 
-            exceptions::ValueError::py_err(
-                format!("the sir0 header in invalid, expected SIR0, found {:?}", value)
-            ),
-        WanError::InvalidEndOfSir0Header(value) => 
-            exceptions::ValueError::py_err(
-                format!("the end of the sir0 header should be four 0, found {:?}", value)
-            ),
-        WanError::TypeOfSpriteUnknown(value) =>
-            exceptions::ValueError::py_err(
-                format!("the type of sprite is unknown (found the sprite type id {}, but this program only known sprite for [0, 1, 3])", value)
-            ),
-        WanError::InvalidColorNumber(value) =>
-            exceptions::ValueError::py_err(
-                format!("the 2 byte that indicate the number of color is invalid (found {}, expected 0 or 1)", value)
+                format!("{}", err)
             ),
     }
 }


### PR DESCRIPTION
I updated pmd_wan and pyo3, and check it still work with skytemple (master). This API of the library shouldn't change.
In pmd_wan, the only change I made are minor API change, and internal change (as well as adding some other possible error).

It display sprite and object wan in skytemple.