### PR TITLE
Ability to import image as static ground object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "anyhow"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+
+[[package]]
 name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +52,49 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "binread"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+dependencies = [
+ "binread_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "binread_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "binwrite"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c3da1db1f384ad643e27cb6ba4f08f2a7cd8753bef8dd95c39fe45d7a474c8"
+dependencies = [
+ "binwrite_derive",
+ "paste",
+]
+
+[[package]]
+name = "binwrite_derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476f17c19ce04226ba997c229ce8fb96eaef1c0e0745ec91d8df35f723aae353"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -220,6 +269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io_partition"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec167c49e5a490450099dc92edff1e0bf1070e63b312a6ae1f60621de96e842"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -402,14 +460,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "pmd_wan"
-version = "1.2.0"
+name = "pmd_sir0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df7bbfbaf667356e1f7647629a5fd3a205335d46573d59157cf08fcf618c65"
+checksum = "33976fa6e0a9243edff561e9470808afcc97cd935c9fd4f3211ef1717791a0c6"
 dependencies = [
+ "byteorder",
+ "io_partition",
+ "thiserror",
+]
+
+[[package]]
+name = "pmd_wan"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abeb8656bbfa97242675eddd8637af9f2efd319e53c36636c08e0bccd9616a53"
+dependencies = [
+ "anyhow",
+ "binread",
+ "binwrite",
  "byteorder",
  "image",
  "log",
+ "pmd_sir0",
  "thiserror",
 ]
 
@@ -541,6 +614,12 @@ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "scoped_threadpool"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "pmd_wan"
-version = "2.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abeb8656bbfa97242675eddd8637af9f2efd319e53c36636c08e0bccd9616a53"
+checksum = "7f4623f3ffa6f09691fc9141fc1d585bd18daf9db14091d7082f8895c4a5f96e"
 dependencies = [
  "anyhow",
  "binread",
@@ -637,6 +637,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 name = "skytemple_rust"
 version = "1.4.0"
 dependencies = [
+ "anyhow",
  "arr_macro",
  "bytes",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ pyo3 = { version = "0.15", features = ["extension-module"], optional = true }
 pyo3-log = { version = "0.5", optional = true }
 log = "0.4"
 skytemple_rust_macros = { path = "skytemple_rust_macros" }
-pmd_wan = "2.0.1"
+pmd_wan = "3.0.1"
 bytes = "1.1.0"
 num-traits = "0.2"
 num-derive = "0.3"
 arr_macro = "0.1.3"
+anyhow = "1.0.51"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pyo3 = { version = "0.15", features = ["extension-module"], optional = true }
 pyo3-log = { version = "0.5", optional = true }
 log = "0.4"
 skytemple_rust_macros = { path = "skytemple_rust_macros" }
-pmd_wan = "1.2.0"
+pmd_wan = "2.0.1"
 bytes = "1.1.0"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ from glob import glob
 from typing import Optional
 
 from PIL import Image
-from skytemple_rust.pmd_wan import MetaFrame, Image as PmdWanImage, Resolution, MetaFrameGroup
+from skytemple_rust.pmd_wan import MetaFrame, ImageBytes, Resolution, MetaFrameGroup
 
 from skytemple_rust import pmd_wan
 from skytemple_files.common.types.file_types import FileType
@@ -27,19 +27,19 @@ for gptrn in glob(WAN_FILE_PATTERN):
                 os.makedirs(f'/tmp/outimg/{basename}/{mfg_i}', exist_ok=True)
                 for mf_i, meta_frame_id in enumerate(meta_frame_group.meta_frames_id):
                     meta_frame = image.meta_frame_store.meta_frames[meta_frame_id]
-                    meta_frame_img: PmdWanImage = image.image_store.images[meta_frame.image_index]
-                    resolution1: Optional[Resolution] = meta_frame.resolution
+                    meta_frame_img_bytes: ImageBytes = image.image_store.images[meta_frame.image_index]
+                    resolution: Resolution = meta_frame.resolution
                     try:
                         im = Image.frombuffer('RGBA',
-                                              (resolution1.x, resolution1.y),
-                                              bytearray(meta_frame_img.img),
+                                              (resolution.x, resolution.y),
+                                              bytearray(meta_frame_img_bytes.to_image(image.palette, meta_frame)),
                                               'raw', 'RGBA', 0, 1)
 
                         im.save(f'/tmp/outimg/{basename}/{mfg_i}/{mf_i}.png')
                     except ValueError as e:
                         print(f"Error converting {basename}/{mfg_i}/{mf_i}: {e}", file=sys.stderr)
         except ValueError as e:
-            print(f"Error converting {basename}/{mfg_i}/{mf_i}: {e}", file=sys.stderr)
+            print(f"Error converting {basename}/{mfg_i}/{mf_i}: {e}", file=sys.stderr)*/
 
 with open(PACK_FILE, 'rb') as f:
     bin_pack = FileType.BIN_PACK.deserialize(f.read())
@@ -54,13 +54,13 @@ with open(PACK_FILE, 'rb') as f:
             os.makedirs(f'/tmp/outimg/{s_i}/{mfg_i}', exist_ok=True)
             for mf_i, meta_frame_id in enumerate(meta_frame_group.meta_frames_id):
                 meta_frame = image.meta_frame_store.meta_frames[meta_frame_id]
-                meta_frame_img: PmdWanImage = image.image_store.images[meta_frame.image_index]
-                resolution1: Optional[Resolution] = meta_frame.resolution
+                meta_frame_img_bytes: ImageBytes = image.image_store.images[meta_frame.image_index]
+                resolution: Optional[Resolution] = meta_frame.resolution
                 try:
                     im = Image.frombuffer('RGBA',
-                                     (resolution1.x, resolution1.y),
-                                     bytearray(meta_frame_img.img),
-                                     'raw', 'RGBA', 0, 1)
+                                          (resolution.x, resolution.y),
+                                          bytearray(meta_frame_img_bytes.to_image(image.palette, meta_frame)),
+                                          'raw', 'RGBA', 0, 1)
 
                     im.save(f'/tmp/outimg/{s_i}/{mfg_i}/{mf_i}.png')
                 except ValueError as e:

--- a/example.py
+++ b/example.py
@@ -39,7 +39,7 @@ for gptrn in glob(WAN_FILE_PATTERN):
                     except ValueError as e:
                         print(f"Error converting {basename}/{mfg_i}/{mf_i}: {e}", file=sys.stderr)
         except ValueError as e:
-            print(f"Error converting {basename}/{mfg_i}/{mf_i}: {e}", file=sys.stderr)*/
+            print(f"Error converting {basename}/{mfg_i}/{mf_i}: {e}", file=sys.stderr)
 
 with open(PACK_FILE, 'rb') as f:
     bin_pack = FileType.BIN_PACK.deserialize(f.read())

--- a/skytemple_rust/pmd_wan.pyi
+++ b/skytemple_rust/pmd_wan.pyi
@@ -16,7 +16,7 @@
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 
 from typing import List, Tuple, Optional
-
+from PIL.Image import Image
 
 class WanImage:
     image_store: ImageStore
@@ -38,20 +38,22 @@ class ImageBytes:
     mixed_pixels: List[int]
     z_index: int
 
+    def decode_image(self, resolution: Resolution) -> List[int]: ...
+
+    def to_image(self, palette: Palette, metaframe: MetaFrame) -> List[int]: ...
+
 
 class MetaFrameStore:
-    meta_frames: List[MetaFrame]
     meta_frame_groups: List[MetaFrameGroup]
 
 
 class MetaFrame:
     unk1: int
     unk2: int
-    unk3: bool
+    unk3_4: Optional[Tuple[bool, bool]]
     image_index: int
     offset_y: int
     offset_x: int
-    is_last: bool
     v_flip: bool
     h_flip: bool
     is_mosaic: bool
@@ -60,7 +62,7 @@ class MetaFrame:
 
 
 class MetaFrameGroup:
-    meta_frames_id: List[int]
+    meta_frames: List[MetaFrame]
 
 
 class Resolution:
@@ -95,7 +97,7 @@ class SpriteType:
     PropsUI: SpriteType
     Chara: SpriteType
     Unknown: SpriteType
-
     name: str
     value: int
 
+def encode_image_to_static_wan_file(image: Image) -> bytes: ...

--- a/skytemple_rust/pmd_wan.pyi
+++ b/skytemple_rust/pmd_wan.pyi
@@ -27,16 +27,15 @@ class WanImage:
     is_256_color: bool
     sprite_type: SpriteType
     unk_1: int
+    unk2: int
 
 
 class ImageStore:
-    images: List[Image]
+    images: List[ImageBytes]
 
 
-class Image:
-    img: List[int]
-    width: int
-    height: int
+class ImageBytes:
+    mixed_pixels: List[int]
     z_index: int
 
 
@@ -57,7 +56,7 @@ class MetaFrame:
     h_flip: bool
     is_mosaic: bool
     pal_idx: int
-    resolution: Optional[Resolution]
+    resolution: Resolution
 
 
 class MetaFrameGroup:
@@ -70,9 +69,8 @@ class Resolution:
 
 
 class AnimStore:
-    animations: List[Animation]
     copied_on_previous: Optional[List[bool]]
-    anim_groups: List[Optional[Tuple[int, int]]]
+    anim_groups: List[List[Animation]]
 
 
 class Animation:
@@ -90,7 +88,7 @@ class AnimationFrame:
 
 
 class Palette:
-    palette: List[Tuple[int, int, int, int]]
+    palette: List[int]
 
 
 class SpriteType:


### PR DESCRIPTION
The main change in pmd_wan 2.0.0 is support for writing wan file, thought this doesn't expose it yet. My goal is to be able to import png as unanimated object sprite. This new version also does some changes in the API, to be closer to the original file format without making it much harder to use it.