### PR TITLE
update pmd_wan to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +75,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -191,15 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "crc32fast"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,16 +226,6 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
-]
-
-[[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
 ]
 
 [[package]]
@@ -366,16 +341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a7187e78088aead22ceedeee99779455b23fc231fe13ec443f99bb71694e5b"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,21 +357,16 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.14"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+checksum = "db207d030ae38f1eb6f240d5a1c1c88ff422aa005d10f8c6c6fc5e75286ab30e"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "gif",
- "jpeg-decoder",
  "num-iter",
  "num-rational",
  "num-traits",
- "png",
- "scoped_threadpool",
- "tiff",
 ]
 
 [[package]]
@@ -457,15 +417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
-]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
-dependencies = [
- "rayon",
 ]
 
 [[package]]
@@ -547,15 +498,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
@@ -609,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -738,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "pmd_wan"
-version = "3.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4623f3ffa6f09691fc9141fc1d585bd18daf9db14091d7082f8895c4a5f96e"
+checksum = "65c83ce34f19e4aae659e244f552ae16f2e8533936e5423860add1b140c1c1fa"
 dependencies = [
  "anyhow",
  "binread",
@@ -750,18 +692,6 @@ dependencies = [
  "log",
  "pmd_sir0",
  "thiserror",
-]
-
-[[package]]
-name = "png"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
-dependencies = [
- "bitflags",
- "crc32fast",
- "deflate",
- "miniz_oxide 0.3.7",
 ]
 
 [[package]]
@@ -911,12 +841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,17 +933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
-dependencies = [
- "jpeg-decoder",
- "miniz_oxide 0.4.4",
- "weezl",
-]
-
-[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,12 +960,6 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "weezl"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ arr_macro = { version = "0.1.3", optional = true }
 encoding = "0.2"
 encoding-index-singlebyte = { version = "1", optional = true }
 chrono = { version = "0.4", optional = true }
-pmd_wan = { version = "3.0.1", optional = true }
+pmd_wan = { version = "4.0.0", optional = true }
 anyhow = { version = "1", optional = true }
 nitro_fs = { version = "0.1", optional = true }
 memmap = { version = "0.7", optional = true }

--- a/skytemple_rust/pmd_wan.pyi
+++ b/skytemple_rust/pmd_wan.pyi
@@ -26,7 +26,7 @@ class WanImage:
     raw_particule_table: List[int]
     is_256_color: bool
     sprite_type: SpriteType
-    unk_1: int
+    size_to_allocate_for_all_metaframe: int
     unk2: int
 
 
@@ -49,7 +49,7 @@ class MetaFrameStore:
 
 class MetaFrame:
     unk1: int
-    unk2: int
+    image_alloc_counter: int
     unk3_4: Optional[Tuple[bool, bool]]
     image_index: int
     offset_y: int

--- a/src/pmd_wan.rs
+++ b/src/pmd_wan.rs
@@ -47,7 +47,7 @@ struct WanImage {
     #[pyo3(get)]
     pub sprite_type: SpriteType,
     #[pyo3(get)]
-    pub unk_1: u32,
+    pub size_to_allocate_for_all_metaframe: u32,
     #[pyo3(get)]
     pub unk2: u16,
 }
@@ -122,7 +122,7 @@ pub struct MetaFrame {
     #[pyo3(get)]
     pub unk1: u16,
     #[pyo3(get)]
-    pub unk2: u16,
+    pub image_alloc_counter: u16,
     #[pyo3(get)]
     pub unk3_4: Option<(bool, bool)>,
     #[pyo3(get)]
@@ -282,7 +282,7 @@ fn wrap_meta_frame_store(lib_ent: &lib::MetaFrameStore) -> MetaFrameStore {
 fn wrap_meta_frame(lib_ent: &lib::MetaFrame) -> MetaFrame {
     MetaFrame {
         unk1: lib_ent.unk1,
-        unk2: lib_ent.unk2,
+        image_alloc_counter: lib_ent.image_alloc_counter,
         unk3_4: lib_ent.unk3_4,
         unk5: lib_ent.unk5,
         image_index: lib_ent.image_index,
@@ -362,7 +362,7 @@ impl WanImage {
                 raw_particule_table: lib_img.raw_particule_table,
                 is_256_color: lib_img.is_256_color,
                 sprite_type: convert_sprite_type(&lib_img.sprite_type),
-                unk_1: lib_img.unk_1,
+                size_to_allocate_for_all_metaframe: lib_img.size_to_allocate_for_all_metaframe,
                 unk2: lib_img.unk2,
             }),
             Err(err) => Err(convert_error(err)),
@@ -406,11 +406,11 @@ pub fn encode_image_to_static_wan_file(py: Python, image: PyObject) -> PyResult<
         raw_particule_table: Vec::new(),
         is_256_color: false,
         sprite_type: lib::SpriteType::PropsUI,
-        unk_1: 0,
+        size_to_allocate_for_all_metaframe: 0,
         unk2: 0,
     };
 
-    let meta_frame_group_id = lib::insert_frame_in_wanimage(
+    let meta_frame_group_id = lib::insert_meta_frame_in_wanimage(
         indexed_image.0.0.0.to_vec(),
         indexed_image.0.1.try_into().map_err(|_| exceptions::PyValueError::new_err("The image is far too wide"))?,
         indexed_image.0.2.try_into().map_err(|_| exceptions::PyValueError::new_err("The image is far too high"))?,


### PR DESCRIPTION
This new version (I just made), feature a better code for generating the static object.

In particular, instead of only using 64x64 image (fragment of a frame), it use the smallest possible size, reducing the memory allocation of those object, which may (or may not) help.

There are also some field being renamed for clarity.