### PR TITLE
Resolve or ignore compiler warnings.

### DIFF
--- a/src/st_bgp.rs
+++ b/src/st_bgp.rs
@@ -153,7 +153,6 @@ impl Bgp {
     }
 
     fn extract_tiles(data: &[u8]) -> Vec<StBytes> {
-        let data_len = data.len();
         data.chunks(BGP_TILE_DIM * BGP_TILE_DIM / 2)
             .map(StBytes::from)
             .collect()

--- a/src/st_dbg.rs
+++ b/src/st_dbg.rs
@@ -32,11 +32,13 @@ pub struct Dbg {
 
 #[pymethods]
 impl Dbg {
+    #[allow(unused_variables)]
     #[new]
     pub fn new(data: StBytes) -> PyResult<Self> {
         todo!()
     }
 
+    #[allow(unused_variables)]
     pub fn to_pil(&self, dpc: InputDpc, dpci: InputDpci, palettes: Vec<Vec<u8>>) -> PyResult<IndexedImage> {
         todo!()
     }
@@ -70,6 +72,7 @@ impl DbgWriter {
     pub fn new() -> Self {
         Self
     }
+    #[allow(unused_variables)]
     pub fn write(&self, model: Py<Dbg>, py: Python) -> PyResult<StBytes> {
         todo!()
     }

--- a/src/st_dma.rs
+++ b/src/st_dma.rs
@@ -17,7 +17,6 @@
  * along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
  */
 use crate::bytes::StBytes;
-use crate::image::IndexedImage;
 use crate::python::*;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -94,6 +93,7 @@ impl Dma {
     /// Returns a few extra chunk variations for the given type.
     /// How they are used exactly by the game is currently not know,
     /// this interface could change if we find out.
+    #[allow(unused_variables)]
     pub fn get_extra(&self, extra_type: DmaExtraType) -> Vec<u8> {
         //      cms = []
         //         for i in range(0x300 * 3, len(self.chunk_mappings)):
@@ -115,6 +115,7 @@ impl Dma {
     }
 
     /// Sets and extra tile entry.
+    #[allow(unused_variables)]
     pub fn set_extra(&mut self, extra_type: DmaExtraType, index: u8, value: usize) {
         //  self.chunk_mappings[(0x300 * 3) + extra_type + (3 * index)] = value
         todo!()

--- a/src/st_dpc.rs
+++ b/src/st_dpc.rs
@@ -31,11 +31,13 @@ pub struct Dpc {
 
 #[pymethods]
 impl Dpc {
+    #[allow(unused_variables)]
     #[new]
     pub fn new(data: StBytes) -> PyResult<Self> {
         todo!()
     }
 
+    #[allow(unused_variables)]
     #[args(width_in_mtiles = "16")]
     /// Convert all chunks of the DPC to one big image.
     /// The chunks are all placed next to each other.
@@ -47,6 +49,7 @@ impl Dpc {
         todo!()
     }
 
+    #[allow(unused_variables)]
     /// Convert a single chunk of the DPC into a image. For general notes, see chunks_to_pil.
     pub fn single_chunk_to_pil(&self, chunk_idx: usize, dpci: InputDpci, palettes: Vec<Vec<u8>>) -> PyResult<IndexedImage> {
         todo!()
@@ -66,6 +69,7 @@ impl Dpc {
         todo!()
     }
 
+    #[allow(unused_variables)]
     #[args(contains_null_chunk = "false", correct_tile_ids = "true")]
     /// Replace the tile mappings of the specified layer.
     /// If contains_null_tile is False, the null chunk is added to the list, at the beginning.
@@ -87,6 +91,7 @@ impl DpcWriter {
     pub fn new() -> Self {
         Self
     }
+    #[allow(unused_variables)]
     pub fn write(&self, model: Py<Dpc>, py: Python) -> PyResult<StBytes> {
         todo!()
     }

--- a/src/st_dpci.rs
+++ b/src/st_dpci.rs
@@ -27,6 +27,7 @@ pub struct Dpci {
 
 #[pymethods]
 impl Dpci {
+    #[allow(unused_variables)]
     #[new]
     pub fn new(data: StBytes) -> PyResult<Self> {
         todo!()
@@ -43,6 +44,7 @@ impl DpciWriter {
     pub fn new() -> Self {
         Self
     }
+    #[allow(unused_variables)]
     pub fn write(&self, model: Py<Dpci>, py: Python) -> PyResult<StBytes> {
         todo!()
     }

--- a/src/st_dpl.rs
+++ b/src/st_dpl.rs
@@ -28,6 +28,7 @@ pub struct Dpl {
 
 #[pymethods]
 impl Dpl {
+    #[allow(unused_variables)]
     #[new]
     pub fn new(data: StBytes) -> PyResult<Self> {
         todo!()
@@ -44,6 +45,7 @@ impl DplWriter {
     pub fn new() -> Self {
         Self
     }
+    #[allow(unused_variables)]
     pub fn write(&self, model: Py<Dpl>, py: Python) -> PyResult<StBytes> {
         todo!()
     }

--- a/src/st_dpla.rs
+++ b/src/st_dpla.rs
@@ -27,6 +27,7 @@ pub struct Dpla {
 
 #[pymethods]
 impl Dpla {
+    #[allow(unused_variables)]
     #[new]
     pub fn new(data: StBytes) -> PyResult<Self> {
         todo!()


### PR DESCRIPTION
It's a small nit, but I'd like to remove these from the console output
when building so that there is more signal to noise.