### PR TITLE
pmd_wan: update to 5.1.1 (break API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "pmd_wan"
-version = "4.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c83ce34f19e4aae659e244f552ae16f2e8533936e5423860add1b140c1c1fa"
+checksum = "cb912d5b203ad7a1a6afe3332867b937ad67760068a6b3df91029c682ff37063"
 dependencies = [
  "anyhow",
  "binread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ arr_macro = { version = "0.1.3", optional = true }
 encoding = "0.2"
 encoding-index-singlebyte = { version = "1", optional = true }
 time = { version = "0.3.14", optional = true }
-pmd_wan = { version = "4.0.0", optional = true }
+pmd_wan = { version = "5.1.1", optional = true }
 anyhow = { version = "1", optional = true }
 thiserror = "1"
 nitro_fs = { version = "0.1", optional = true }

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ from glob import glob
 from typing import Optional
 
 from PIL import Image
-from skytemple_rust.pmd_wan import MetaFrame, ImageBytes, Resolution, MetaFrameGroup
+from skytemple_rust.pmd_wan import Fragment, ImageBytes, FragmentResolution, Frame
 
 from skytemple_rust import pmd_wan
 from skytemple_files.common.types.file_types import FileType
@@ -21,18 +21,18 @@ for gptrn in glob(WAN_FILE_PATTERN):
         try:
             image = pmd_wan.WanImage(f.read())
 
-            meta_frame: MetaFrame
-            meta_frame_group: MetaFrameGroup
-            for mfg_i, meta_frame_group in enumerate(image.meta_frame_store.meta_frame_groups):
+            fragment: Fragment
+            frame: Frame
+            for mfg_i, frame in enumerate(image.meta_frame_store.meta_frame_groups):
                 os.makedirs(f'/tmp/outimg/{basename}/{mfg_i}', exist_ok=True)
-                for mf_i, meta_frame_id in enumerate(meta_frame_group.meta_frames_id):
-                    meta_frame = image.meta_frame_store.meta_frames[meta_frame_id]
-                    meta_frame_img_bytes: ImageBytes = image.image_store.images[meta_frame.image_index]
-                    resolution: Resolution = meta_frame.resolution
+                for mf_i, meta_frame_id in enumerate(frame.meta_frames_id):
+                    fragment = image.meta_frame_store.meta_frames[meta_frame_id]
+                    meta_frame_img_bytes: ImageBytes = image.image_store.images[fragment.image_index]
+                    resolution: FragmentResolution = fragment.resolution
                     try:
                         im = Image.frombuffer('RGBA',
                                               (resolution.x, resolution.y),
-                                              bytearray(meta_frame_img_bytes.to_image(image.palette, meta_frame)),
+                                              bytearray(meta_frame_img_bytes.to_image(image.palette, fragment)),
                                               'raw', 'RGBA', 0, 1)
 
                         im.save(f'/tmp/outimg/{basename}/{mfg_i}/{mf_i}.png')
@@ -48,18 +48,18 @@ with open(PACK_FILE, 'rb') as f:
         sprite_bin_decompressed = FileType.PKDPX.deserialize(sprite).decompress()
         image = pmd_wan.WanImage(sprite_bin_decompressed)
 
-        meta_frame: MetaFrame
-        meta_frame_group: MetaFrameGroup
-        for mfg_i, meta_frame_group in enumerate(image.meta_frame_store.meta_frame_groups):
+        fragment: Fragment
+        frame: Frame
+        for mfg_i, frame in enumerate(image.meta_frame_store.meta_frame_groups):
             os.makedirs(f'/tmp/outimg/{s_i}/{mfg_i}', exist_ok=True)
-            for mf_i, meta_frame_id in enumerate(meta_frame_group.meta_frames_id):
-                meta_frame = image.meta_frame_store.meta_frames[meta_frame_id]
-                meta_frame_img_bytes: ImageBytes = image.image_store.images[meta_frame.image_index]
-                resolution: Optional[Resolution] = meta_frame.resolution
+            for mf_i, meta_frame_id in enumerate(frame.meta_frames_id):
+                fragment = image.meta_frame_store.meta_frames[meta_frame_id]
+                meta_frame_img_bytes: ImageBytes = image.image_store.images[fragment.image_index]
+                resolution: Optional[FragmentResolution] = fragment.resolution
                 try:
                     im = Image.frombuffer('RGBA',
                                           (resolution.x, resolution.y),
-                                          bytearray(meta_frame_img_bytes.to_image(image.palette, meta_frame)),
+                                          bytearray(meta_frame_img_bytes.to_image(image.palette, fragment)),
                                           'raw', 'RGBA', 0, 1)
 
                     im.save(f'/tmp/outimg/{s_i}/{mfg_i}/{mf_i}.png')

--- a/skytemple_rust/pmd_wan.pyi
+++ b/skytemple_rust/pmd_wan.pyi
@@ -19,58 +19,65 @@ from typing import List, Tuple, Optional
 from PIL.Image import Image
 
 class WanImage:
-    image_store: ImageStore
-    meta_frame_store: MetaFrameStore
-    anim_store: AnimStore
+    fragment_bytes_store: FragmentBytesStore
+    frame_store: FrameStore
+    animation_store: AnimationStore
     palette: Palette
-    raw_particule_table: List[int]
     is_256_color: bool
     sprite_type: SpriteType
-    size_to_allocate_for_all_metaframe: int
     unk2: int
 
 
-class ImageStore:
-    images: List[ImageBytes]
+class FragmentBytesStore:
+    fragment_bytes: List[FragmentBytes]
 
 
-class ImageBytes:
+class FragmentBytes:
     mixed_pixels: List[int]
     z_index: int
 
-    def decode_image(self, resolution: Resolution) -> List[int]: ...
+    def decode_fragment(self, resolution: FragmentResolution) -> List[int]: ...
 
-    def to_image(self, palette: Palette, metaframe: MetaFrame) -> List[int]: ...
-
-
-class MetaFrameStore:
-    meta_frame_groups: List[MetaFrameGroup]
+    def to_image(self, palette: Palette, fragment: Fragment) -> List[int]: ...
 
 
-class MetaFrame:
+class FrameStore:
+    frames: List[Frame]
+    max_fragment_alloc_count: int
+
+
+class Fragment:
     unk1: int
-    image_alloc_counter: int
     unk3_4: Optional[Tuple[bool, bool]]
-    image_index: int
+    unk5: bool
+    fragment_bytes_index: int
     offset_y: int
     offset_x: int
-    v_flip: bool
-    h_flip: bool
+    flip: FragmentFlip
     is_mosaic: bool
     pal_idx: int
-    resolution: Resolution
+    resolution: FragmentResolution
 
+class FragmentFlip:
+    flip_h: bool
+    flip_v: bool
 
-class MetaFrameGroup:
-    meta_frames: List[MetaFrame]
+class Frame:
+    fragments: List[Fragment]
+    frame_offset: Optional[FrameOffset]
 
+class FrameOffset:
+    head: Tuple[int, int]
+    hand_left: Tuple[int, int]
+    hand_right: Tuple[int, int]
+    center: Tuple[int, int]
 
-class Resolution:
+class FragmentResolution:
     x: int
     y: int
 
 
-class AnimStore:
+class AnimationStore:
     copied_on_previous: Optional[List[bool]]
     anim_groups: List[List[Animation]]
 

--- a/src/pmd_wan.rs
+++ b/src/pmd_wan.rs
@@ -31,36 +31,32 @@ use crate::image::{In16ColIndexedImage, InIndexedImage};
 #[derive(Clone)]
 struct WanImage {
     #[pyo3(get)]
-    pub image_store: ImageStore,
+    pub fragment_bytes_store: FragmentBytesStore,
     #[pyo3(get)]
-    pub meta_frame_store: MetaFrameStore,
+    pub frame_store: FrameStore,
     #[pyo3(get)]
-    pub anim_store: AnimStore,
+    pub animation_store: AnimationStore,
     #[pyo3(get)]
     pub palette: Palette,
-    #[pyo3(get)]
-    pub raw_particule_table: Vec<u8>,
     #[pyo3(get)]
     /// true if the picture have 256 color, false if it only have 16
     pub is_256_color: bool,
     #[pyo3(get)]
     pub sprite_type: SpriteType,
     #[pyo3(get)]
-    pub size_to_allocate_for_all_metaframe: u32,
-    #[pyo3(get)]
     pub unk2: u16,
 }
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Clone)]
-struct ImageStore {
+struct FragmentBytesStore {
     #[pyo3(get)]
-    pub images: Vec<ImageBytes>,
+    pub fragment_bytes: Vec<FragmentBytes>,
 }
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Clone)]
-pub struct ImageBytes {
+pub struct FragmentBytes {
     #[pyo3(get)]
     pub mixed_pixels: Vec<u8>,
     #[pyo3(get)]
@@ -68,27 +64,27 @@ pub struct ImageBytes {
 }
 
 #[pymethods]
-impl ImageBytes {
-    pub fn decode_image(&self, resolution: &Resolution) -> PyResult<Vec<u8>> {
-        lib::decode_image_pixel(
+impl FragmentBytes {
+    pub fn decode_fragment(&self, resolution: &FragmentResolution) -> PyResult<Vec<u8>> {
+        lib::decode_fragment_pixels(
             &self.mixed_pixels,
-            &lib::Resolution {
-                x: resolution.x,
-                y: resolution.y,
-            },
+            &lib::FragmentResolution::new(
+                resolution.x,
+                resolution.y,
+            ),
         )
-        .map_err(convert_decode_image_error)
+        .map_err(convert_decode_fragment_bytes_error)
     }
 
-    pub fn to_image(&self, palette: &Palette, metaframe: &MetaFrame) -> PyResult<Vec<u8>> {
-        let decoded = self.decode_image(&metaframe.resolution)?;
+    pub fn to_image(&self, palette: &Palette, fragment: &Fragment) -> PyResult<Vec<u8>> {
+        let decoded = self.decode_fragment(&fragment.resolution)?;
         let mut target: Vec<u8> =
-            Vec::with_capacity(metaframe.resolution.x as usize * metaframe.resolution.y as usize);
+            Vec::with_capacity(fragment.resolution.x as usize * fragment.resolution.y as usize);
         for pixel in decoded {
             if pixel == 0 {
-                target.extend(&[0, 0, 0, 0])
+                target.extend([0, 0, 0, 0])
             } else {
-                let color_id = metaframe.pal_idx as usize * 16 + pixel as usize;
+                let color_id = fragment.pal_idx as usize * 16 + pixel as usize;
                 match palette.palette.get(color_id) {
                     Some(v) => {
                         let mut v = *v;
@@ -110,50 +106,72 @@ impl ImageBytes {
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Clone)]
-pub struct MetaFrameStore {
+pub struct FrameStore {
     #[pyo3(get)]
-    pub meta_frame_groups: Vec<MetaFrameGroup>,
+    pub frames: Vec<Frame>,
+    #[pyo3(get)]
+    pub max_fragment_alloc_count: u16
 }
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Clone)]
-pub struct MetaFrame {
+pub struct Fragment {
     #[pyo3(get)]
     pub unk1: u16,
-    #[pyo3(get)]
-    pub image_alloc_counter: u16,
     #[pyo3(get)]
     pub unk3_4: Option<(bool, bool)>,
     #[pyo3(get)]
     pub unk5: bool,
     #[pyo3(get)]
-    pub image_index: usize,
+    pub fragment_bytes_index: usize,
     #[pyo3(get)]
     pub offset_y: i8,
     #[pyo3(get)]
     pub offset_x: i16,
     #[pyo3(get)]
-    pub v_flip: bool,
-    #[pyo3(get)]
-    pub h_flip: bool,
+    pub flip: FragmentFlip,
     #[pyo3(get)]
     pub is_mosaic: bool,
     #[pyo3(get)]
     pub pal_idx: u16,
     #[pyo3(get)]
-    pub resolution: Resolution,
+    pub resolution: FragmentResolution,
 }
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Clone)]
-pub struct MetaFrameGroup {
+pub struct FragmentFlip {
     #[pyo3(get)]
-    pub meta_frames: Vec<MetaFrame>,
+    pub flip_h: bool,
+    #[pyo3(get)]
+    pub flip_v: bool
+}
+
+#[pyclass(module = "skytemple_rust.pmd_wan")]
+#[derive(Clone)]
+pub struct Frame {
+    #[pyo3(get)]
+    pub fragments: Vec<Fragment>,
+    #[pyo3(get)]
+    pub frame_offset: Option<FrameOffset>
+}
+
+#[pyclass(module = "skytemple_rust.pmd_wan")]
+#[derive(Clone)]
+pub struct FrameOffset {
+    #[pyo3(get)]
+    head: (i16, i16),
+    #[pyo3(get)]
+    hand_left: (i16, i16),
+    #[pyo3(get)]
+    hand_right: (i16, i16),
+    #[pyo3(get)]
+    center: (i16, i16),
 }
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Copy, Clone)]
-pub struct Resolution {
+pub struct FragmentResolution {
     #[pyo3(get)]
     pub x: u8,
     #[pyo3(get)]
@@ -162,7 +180,7 @@ pub struct Resolution {
 
 #[pyclass(module = "skytemple_rust.pmd_wan")]
 #[derive(Clone)]
-pub struct AnimStore {
+pub struct AnimationStore {
     #[pyo3(get)]
     pub copied_on_previous: Option<Vec<bool>>, //indicate if a sprite can copy on the previous. Will always copy if possible if None
     #[pyo3(get)]
@@ -259,57 +277,68 @@ fn wrap_vec<T, U>(vector: &[T], convert_cb: fn(&T) -> U) -> Vec<U> {
     vector.iter().map(convert_cb).collect()
 }
 
-fn wrap_image_store(lib_ent: &lib::ImageStore) -> ImageStore {
-    ImageStore {
-        images: wrap_vec(&lib_ent.images, wrap_image),
+fn wrap_fragment_bytes_store(lib_ent: &lib::FragmentBytesStore) -> FragmentBytesStore {
+    FragmentBytesStore {
+        fragment_bytes: wrap_vec(&lib_ent.fragment_bytes, wrap_fragment_bytes),
     }
 }
 
-fn wrap_image(lib_ent: &lib::ImageBytes) -> ImageBytes {
-    ImageBytes {
+fn wrap_fragment_bytes(lib_ent: &lib::FragmentBytes) -> FragmentBytes {
+    FragmentBytes {
         mixed_pixels: lib_ent.mixed_pixels.clone(),
         z_index: lib_ent.z_index,
     }
 }
 
-fn wrap_meta_frame_store(lib_ent: &lib::MetaFrameStore) -> MetaFrameStore {
-    MetaFrameStore {
-        meta_frame_groups: wrap_vec(&lib_ent.meta_frame_groups, wrap_meta_frame_group),
+fn wrap_frame_store(lib_ent: &lib::FrameStore) -> FrameStore {
+    FrameStore {
+        frames: wrap_vec(&lib_ent.frames, wrap_frame),
+        max_fragment_alloc_count: lib_ent.compute_fragment_alloc_counter()
     }
 }
 
-fn wrap_meta_frame(lib_ent: &lib::MetaFrame) -> MetaFrame {
-    MetaFrame {
+fn wrap_fragment(lib_ent: &lib::Fragment) -> Fragment {
+    Fragment {
         unk1: lib_ent.unk1,
-        image_alloc_counter: lib_ent.image_alloc_counter,
         unk3_4: lib_ent.unk3_4,
         unk5: lib_ent.unk5,
-        image_index: lib_ent.image_index,
+        fragment_bytes_index: lib_ent.fragment_bytes_index,
         offset_y: lib_ent.offset_y,
         offset_x: lib_ent.offset_x,
-        v_flip: lib_ent.v_flip,
-        h_flip: lib_ent.h_flip,
+        flip: wrap_fragment_flip(lib_ent.flip),
         is_mosaic: lib_ent.is_mosaic,
         pal_idx: lib_ent.pal_idx,
-        resolution: wrap_resolution(&lib_ent.resolution),
+        resolution: wrap_fragment_resolution(&lib_ent.resolution)
     }
 }
 
-fn wrap_meta_frame_group(lib_ent: &lib::MetaFrameGroup) -> MetaFrameGroup {
-    MetaFrameGroup {
-        meta_frames: wrap_vec(&lib_ent.meta_frames, wrap_meta_frame),
+fn wrap_fragment_flip(lib_ent: lib::FragmentFlip) -> FragmentFlip {
+    FragmentFlip {
+        flip_h: lib_ent.flip_h,
+        flip_v: lib_ent.flip_v
     }
 }
 
-fn wrap_resolution(lib_ent: &lib::Resolution) -> Resolution {
-    Resolution {
+fn wrap_frame(lib_ent: &lib::Frame) -> Frame {
+    Frame {
+        fragments: wrap_vec(&lib_ent.fragments, wrap_fragment),
+        frame_offset: lib_ent.frame_offset.as_ref().map(wrap_frame_offset),
+    }
+}
+
+fn wrap_frame_offset(lib_ent: &lib::FrameOffset) -> FrameOffset {
+    FrameOffset { head: lib_ent.head, hand_left: lib_ent.hand_left, hand_right: lib_ent.hand_right, center: lib_ent.center }
+}
+
+fn wrap_fragment_resolution(lib_ent: &lib::FragmentResolution) -> FragmentResolution {
+    FragmentResolution {
         x: lib_ent.x,
         y: lib_ent.y,
     }
 }
 
-fn wrap_anim_store(lib_ent: &lib::AnimStore) -> AnimStore {
-    AnimStore {
+fn wrap_animation_store(lib_ent: &lib::AnimationStore) -> AnimationStore {
+    AnimationStore {
         anim_groups: wrap_vec(&lib_ent.anim_groups, |x| wrap_vec(x, wrap_animation)),
         copied_on_previous: lib_ent.copied_on_previous.clone(),
     }
@@ -354,14 +383,12 @@ impl WanImage {
         let result = lib::WanImage::decode_wan(Cursor::new(data));
         match result {
             Ok(lib_img) => Ok(WanImage {
-                image_store: wrap_image_store(&lib_img.image_store),
-                meta_frame_store: wrap_meta_frame_store(&lib_img.meta_frame_store),
-                anim_store: wrap_anim_store(&lib_img.anim_store),
+                fragment_bytes_store: wrap_fragment_bytes_store(&lib_img.fragment_bytes_store),
+                frame_store: wrap_frame_store(&lib_img.frame_store),
+                animation_store: wrap_animation_store(&lib_img.animation_store),
                 palette: wrap_palette(&lib_img.palette),
-                raw_particule_table: lib_img.raw_particule_table,
                 is_256_color: lib_img.is_256_color,
                 sprite_type: convert_sprite_type(&lib_img.sprite_type),
-                size_to_allocate_for_all_metaframe: lib_img.size_to_allocate_for_all_metaframe,
                 unk2: lib_img.unk2,
             }),
             Err(err) => Err(convert_error(err)),
@@ -376,7 +403,7 @@ fn convert_error(err: lib::WanError) -> PyErr {
     }
 }
 
-fn convert_decode_image_error(err: lib::DecodeImageError) -> PyErr {
+fn convert_decode_fragment_bytes_error(err: lib::DecodeFragmentBytesError) -> PyErr {
     exceptions::PyValueError::new_err(format!("{}", err))
 }
 
@@ -399,19 +426,10 @@ pub fn encode_image_to_static_wan_file(py: Python, image: PyObject) -> PyResult<
         palette.push([color[0], color[1], color[2], 128]);
     }
 
-    let mut wanimage = lib::WanImage {
-        image_store: lib::ImageStore { images: Vec::new() },
-        meta_frame_store: lib::MetaFrameStore::default(),
-        anim_store: lib::AnimStore::default(),
-        palette: lib::Palette { palette },
-        raw_particule_table: Vec::new(),
-        is_256_color: false,
-        sprite_type: lib::SpriteType::PropsUI,
-        size_to_allocate_for_all_metaframe: 0,
-        unk2: 0,
-    };
+    let mut wanimage = lib::WanImage::new(lib::SpriteType::PropsUI);
+    wanimage.palette.palette = palette;
 
-    let meta_frame_group_id = lib::insert_meta_frame_in_wanimage(
+    let frame_id = lib::insert_frame_in_wanimage(
         indexed_image.0 .0 .0.to_vec(),
         indexed_image
             .0
@@ -428,12 +446,12 @@ pub fn encode_image_to_static_wan_file(py: Python, image: PyObject) -> PyResult<
     )
     .map_err(convert_anyhow_error_to_user)?;
 
-    if let Some(meta_frame_group_id) = meta_frame_group_id {
-        wanimage.anim_store.anim_groups.push(vec![lib::Animation {
+    if let Some(frame_id) = frame_id {
+        wanimage.animation_store.anim_groups.push(vec![lib::Animation {
             frames: vec![lib::AnimationFrame {
                 duration: 1,
                 flag: 0,
-                frame_id: meta_frame_group_id as u16,
+                frame_id: frame_id as u16,
                 offset_x: 0,
                 offset_y: 0,
                 shadow_offset_x: 0,
@@ -458,13 +476,15 @@ pub(crate) fn create_pmd_wan_module(py: Python) -> PyResult<(&str, &PyModule)> {
     let name: &'static str = "skytemple_rust.pmd_wan";
     let m = PyModule::new(py, name)?;
     m.add_class::<WanImage>()?;
-    m.add_class::<ImageStore>()?;
-    m.add_class::<ImageBytes>()?;
-    m.add_class::<MetaFrameStore>()?;
-    m.add_class::<MetaFrame>()?;
-    m.add_class::<MetaFrameGroup>()?;
-    m.add_class::<Resolution>()?;
-    m.add_class::<AnimStore>()?;
+    m.add_class::<FragmentBytesStore>()?;
+    m.add_class::<FragmentBytes>()?;
+    m.add_class::<FrameStore>()?;
+    m.add_class::<Fragment>()?;
+    m.add_class::<FragmentFlip>()?;
+    m.add_class::<Frame>()?;
+    m.add_class::<FrameOffset>()?;
+    m.add_class::<FragmentResolution>()?;
+    m.add_class::<AnimationStore>()?;
     m.add_class::<Animation>()?;
     m.add_class::<AnimationFrame>()?;
     m.add_class::<Palette>()?;


### PR DESCRIPTION
Getting ready to add an improved compression algorithm. For now, this just update to the latest version of pmd_wan, which include it. I’ll make other PR against skytemple-files and skytemple to be compatible with this.

Should we raise the major version?